### PR TITLE
Add Synth Society merch button to Lab

### DIFF
--- a/src/components/ui/synth-society-merch-button.tsx
+++ b/src/components/ui/synth-society-merch-button.tsx
@@ -1,0 +1,36 @@
+import { ArrowUpRight } from 'lucide-react'
+
+const BUTTON_TEXT = 'SYNTH SOCIETY MERCH'
+const characterRotation = 360 / BUTTON_TEXT.length
+
+export const SynthSocietyMerchButton = () => {
+  return (
+    <a
+      href="https://syncty.xyz/"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Visit Synth Society Merch"
+      className="group relative grid h-[116px] w-[116px] place-items-center rounded-full border border-dotted border-white/75 text-[10px] font-semibold tracking-[0.08em] text-white transition duration-300 hover:border-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-4 focus-visible:ring-offset-black sm:h-[124px] sm:w-[124px]"
+    >
+      <span className="synth-merch-rotation absolute inset-0" aria-hidden="true">
+        {Array.from(BUTTON_TEXT).map((character, index) => (
+          <span
+            key={`${character}-${index}`}
+            className="absolute inset-[6px] inline-block select-none"
+            style={{
+              transform: `rotate(${characterRotation * index}deg)`,
+              transformOrigin: '50% 50%',
+            }}
+          >
+            {character === ' ' ? '\u00A0' : character}
+          </span>
+        ))}
+      </span>
+
+      <span className="relative grid h-11 w-11 place-items-center overflow-hidden rounded-full bg-white text-black transition duration-300 group-hover:scale-105">
+        <ArrowUpRight className="absolute h-5 w-5 transition duration-300 group-hover:translate-x-8 group-hover:-translate-y-8" strokeWidth={1.8} />
+        <ArrowUpRight className="absolute h-5 w-5 -translate-x-8 translate-y-8 transition duration-300 delay-75 group-hover:translate-x-0 group-hover:translate-y-0" strokeWidth={1.8} />
+      </span>
+    </a>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -57,6 +57,22 @@ button.upload:hover {
   }
 }
 
+@keyframes synth-merch-rotation {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.synth-merch-rotation {
+  animation: synth-merch-rotation 10s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .synth-merch-rotation {
+    animation: none;
+  }
+}
+
 .lab-ambient-glow {
   animation: lab-ambient-pulse 8s ease-in-out infinite;
 }
@@ -381,4 +397,4 @@ body {
   100% {
     width: 95%;
   }
-} 
+}

--- a/src/screens/LabScreen.tsx
+++ b/src/screens/LabScreen.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { Helmet } from 'react-helmet-async'
-import { GooeyText } from '@/components/ui/gooey-text-morphing'
 import { SparklesCore } from '@/components/ui/sparkles'
-
-const MORPH_TEXTS = ['Music', 'Fashion', 'Culture']
+import { SynthSocietyMerchButton } from '@/components/ui/synth-society-merch-button'
 
 const SOCIAL_LINKS: { href: string; icon: string; label: string }[] = [
   { href: 'https://open.spotify.com/artist/0h4zpa0iYWK5bzLO19F8Bo', icon: '/spotify.svg', label: 'Spotify' },
@@ -70,25 +68,17 @@ const LabScreen: React.FC = () => {
             <img
               src="/logo-new.png"
               alt="StefnaXYZ"
-              className="mb-8 h-auto w-[min(42vw,148px)] select-none rounded-2xl object-contain sm:mb-10 sm:w-[min(34vw,168px)]"
-              width={168}
+              className="mb-5 h-auto w-[min(38vw,124px)] select-none rounded-2xl object-contain sm:mb-6 sm:w-[min(30vw,140px)]"
+              width={140}
               height={84}
               draggable={false}
             />
 
-            <div className="w-full max-w-4xl">
-              <GooeyText
-                texts={MORPH_TEXTS}
-                morphTime={1.1}
-                cooldownTime={0.3}
-                className="h-[min(14vw,110px)] w-full font-figtree sm:h-[min(12vw,130px)]"
-                textClassName="font-bold"
-              />
-            </div>
+            <SynthSocietyMerchButton />
 
             {/* Social links */}
             <nav
-              className="mt-3 flex max-w-2xl flex-wrap items-center justify-center gap-2.5 sm:mt-4 sm:gap-3"
+              className="mt-7 flex max-w-2xl flex-wrap items-center justify-center gap-2.5 sm:mt-8 sm:gap-3"
               aria-label="Social and streaming links"
             >
               {SOCIAL_LINKS.map((item) => (


### PR DESCRIPTION
## What changed
- Replaced the animated `Music / Fashion / Culture` hero text on `/Lab` with a circular, rotating **SYNTH SOCIETY MERCH** button.
- Linked the button to `https://syncty.xyz/` in a new tab.
- Reduced the StefnaXYZ logo size to give the button room beneath it.
- Added keyboard focus and reduced-motion support.

## Validation
- Checked the diff for whitespace and patch safety.
- Full local TypeScript/build validation could not run because npm failed while unpacking the repository's Netlify CLI dependency in this environment.